### PR TITLE
Fixed bug in Python 3.6

### DIFF
--- a/geminipy/__init__.py
+++ b/geminipy/__init__.py
@@ -240,8 +240,8 @@ class Geminipy(object):
         params -- a dictionary of parameters
         """
         jsonparams = json.dumps(params)
-        payload = base64.b64encode(jsonparams)
-        signature = hmac.new(self.secret_key, payload,
+        payload = base64.b64encode(jsonparams.encode())
+        signature = hmac.new(self.secret_key.encode(), payload,
                              hashlib.sha384).hexdigest()
 
         return {'X-GEMINI-APIKEY': self.api_key,


### PR DESCRIPTION
Fixed an issue that would make the prepare function throw an exception in Python 3.6 (due to the differences in bytes and str types)
Added `.encode()` to the secret API key and parameters in `prepare`, it works correctly now.